### PR TITLE
Add header block in base template

### DIFF
--- a/templates/public/template/base.html
+++ b/templates/public/template/base.html
@@ -49,19 +49,7 @@
     </div>	
   </nav>	
 
-  <header class="masthead text-center text-white">	
-    <div class="masthead-content">	
-      <div class="container">	
-        <h1 class="masthead-heading mb-0">One Page Wonder</h1>	
-        <h2 class="masthead-subheading mb-0">Will Rock Your Socks Off</h2>	
-        <a href="#" class="btn btn-primary btn-xl rounded-pill mt-5">Learn More</a>	
-      </div>	
-    </div>	
-    <div class="bg-circle-1 bg-circle"></div>	
-    <div class="bg-circle-2 bg-circle"></div>	
-    <div class="bg-circle-3 bg-circle"></div>	
-    <div class="bg-circle-4 bg-circle"></div>	
-  </header>	
+  {% block header %}{% endblock %}
 
   <!-- Main content -->	
 <main class="content">	


### PR DESCRIPTION
Change made to base template. 

Added new section for block header, which replaced the default page header information that came with bootstrap template.